### PR TITLE
step11 - 동시에 잔액 충전 요청에 대해 낙관적 락 적용

### DIFF
--- a/src/main/kotlin/com/hhplus/e_commerce/business/entity/Balance.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/business/entity/Balance.kt
@@ -16,6 +16,9 @@ class Balance(
     var user: User = user
         protected set
 
+    @Version
+    var version: Long = 0
+
     @Column(name = "amount", nullable = false)
     var amount: Int = amount
         protected set

--- a/src/main/kotlin/com/hhplus/e_commerce/common/error/code/ErrorCode.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/common/error/code/ErrorCode.kt
@@ -33,6 +33,7 @@ sealed interface ErrorCode {
         override val message: String,
     ) : ErrorCode {
         BAD_REQUEST_BALANCE(HttpStatus.BAD_REQUEST, "BALANCE001", "잘못된 잔액 충전 요청입니다."),
+        ALREADY_CHARGED(HttpStatus.BAD_REQUEST, "BALANCE002", "이미 충전 완료된 요청입니다."),
     }
 
     enum class Product(

--- a/src/main/kotlin/com/hhplus/e_commerce/infra/jpa/BalanceJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/infra/jpa/BalanceJpaRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query
 
 interface BalanceJpaRepository: JpaRepository<Balance, Long> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.OPTIMISTIC)
     @Query("select b from Balance b where b.user.id = :userId")
     fun findByUserIdWithLock(userId: Long): Balance?
 

--- a/src/test/kotlin/com/hhplus/e_commerce/business/facade/BalanceFacadeTest.kt
+++ b/src/test/kotlin/com/hhplus/e_commerce/business/facade/BalanceFacadeTest.kt
@@ -110,13 +110,13 @@ class BalanceFacadeTest {
         val balance = BalanceStub.create(saveUser, 500)
         balanceRepository.save(balance)
 
-        val executor = Executors.newFixedThreadPool(100)
-        val latch = CountDownLatch(100)
+        val executor = Executors.newFixedThreadPool(10)
+        val latch = CountDownLatch(10)
         val results = Collections.synchronizedList(mutableListOf<Result<UserBalanceDto>>())
 
         // when
         try {
-            repeat(100) {
+            repeat(10) {
                 executor.submit {
                     try {
                         val balanceChargeDto = BalanceChargeDto(
@@ -143,7 +143,7 @@ class BalanceFacadeTest {
         val failCount = results.count{ it.isFailure }
 
         assertThat(successCount).isEqualTo(1)
-        assertThat(failCount).isEqualTo(99)
+        assertThat(failCount).isEqualTo(9)
 
         val resultUserBalance = balanceService.getUserBalance(saveUser.id)
         assertThat(resultUserBalance.currentAmount).isEqualTo(1000)


### PR DESCRIPTION
- 작업 내역
-  [x] 잔액 충전 요청 낙관적 락 적용

---

- 리뷰 포인트

잔액 충전 요청에 대해 Pessimistic Lock -> Optimistic Lock 수정해서 테스트 해봤습니다.
통합 테스트에서 스레드를 10개에 대한 요청은 정상적으로 동작하는데, 100개로 늘려 테스트 해보니 성공하지 않았습니다.

공유 자원에 대한 접근이 많이 안 일어난다고 가정하고 사용하는 Lock 이여서 Optimistic Lock의 한계라고 생각합니다.

---
메인 branch merge 목적이 아닌, 팀원들과 코드를 공유하기 위한 PR 입니다.
