### PR TITLE
step11 - 동시에 주문 요청 시 비관적 락 적용

### DIFF
--- a/src/main/kotlin/com/hhplus/e_commerce/business/facade/OrderFacade.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/business/facade/OrderFacade.kt
@@ -5,8 +5,6 @@ import com.hhplus.e_commerce.business.facade.dto.OrderSaveResultDto
 import com.hhplus.e_commerce.business.service.BalanceService
 import com.hhplus.e_commerce.business.service.OrderService
 import com.hhplus.e_commerce.business.service.ProductStockService
-import com.hhplus.e_commerce.common.error.code.ErrorCode
-import com.hhplus.e_commerce.common.error.exception.BusinessException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,6 +17,7 @@ class OrderFacade(
 
     @Transactional
     fun saveOrder(orderSaveDto: OrderSaveDto): OrderSaveResultDto {
+
         // 상품 존재 하는지 조회
         val orderProducts = productStockService.valid(orderSaveDto.products)
 

--- a/src/main/kotlin/com/hhplus/e_commerce/business/repository/ProductStockRepository.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/business/repository/ProductStockRepository.kt
@@ -13,4 +13,8 @@ interface ProductStockRepository {
     fun saveAll(productStocks: List<ProductStock>)
 
     fun deleteAll()
+
+    fun findByIdsWithLock(productStockIds: List<Long>): List<ProductStock>
+
+    fun findExistingIds(productStockIds: List<Long>): List<Long>
 }

--- a/src/main/kotlin/com/hhplus/e_commerce/common/error/code/ErrorCode.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/common/error/code/ErrorCode.kt
@@ -51,6 +51,7 @@ sealed interface ErrorCode {
     ) : ErrorCode {
         NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "ORDER001", "주문 이력을 찾을 수 없습니다."),
         INVALID_ORDER_STATUS(HttpStatus.BAD_REQUEST, "ORDER002", "주문 완료된 주문 번호가 아닙니다."),
+        LOCK_ACQUISITION_FAILED(HttpStatus.BAD_REQUEST, "ORDER003", "결제 진행 중인 상품 입니다."),
     }
 
     enum class Carts(

--- a/src/main/kotlin/com/hhplus/e_commerce/infra/impl/ProductStockRepositoryImpl.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/infra/impl/ProductStockRepositoryImpl.kt
@@ -31,4 +31,12 @@ class ProductStockRepositoryImpl(
         productStockJpaRepository.deleteAll()
     }
 
+    override fun findByIdsWithLock(productStockIds: List<Long>): List<ProductStock> {
+        return productStockJpaRepository.findByIdsWithLock(productStockIds)
+    }
+
+    override fun findExistingIds(productStockIds: List<Long>): List<Long> {
+        return productStockJpaRepository.findExistingIds(productStockIds)
+    }
+
 }

--- a/src/main/kotlin/com/hhplus/e_commerce/infra/jpa/ProductStockJpaRepository.kt
+++ b/src/main/kotlin/com/hhplus/e_commerce/infra/jpa/ProductStockJpaRepository.kt
@@ -5,10 +5,18 @@ import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ProductStockJpaRepository: JpaRepository<ProductStock, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM ProductStock p WHERE p.id = :productStockId")
     fun findByIdWithLock(productStockId: Long): ProductStock?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM ProductStock p WHERE p.id IN :productStockIds")
+    fun findByIdsWithLock(@Param("productStockIds") productStockIds: List<Long>): List<ProductStock>
+
+    @Query("SELECT p.id FROM ProductStock p WHERE p.id IN :productStockIds")
+    fun findExistingIds(productStockIds: List<Long>): List<Long>
 }

--- a/src/test/kotlin/com/hhplus/e_commerce/business/service/ProductStockServiceTest.kt
+++ b/src/test/kotlin/com/hhplus/e_commerce/business/service/ProductStockServiceTest.kt
@@ -38,8 +38,8 @@ class ProductStockServiceTest {
         val productStock1 = ProductStockStub.create(productId = 1L, size = "M", quantity = 10)
         val productStock2 = ProductStockStub.create(productId = 2L, size = "L", quantity = 5)
 
-        every { productStockRepository.findByIdWithLock(1L) } returns productStock1
-        every { productStockRepository.findByIdWithLock(2L) } returns productStock2
+        every { productStockRepository.findExistingIds(listOf(1L, 2L)) } returns listOf(1L, 2L)
+        every { productStockRepository.findByIdsWithLock(listOf(1L, 2L)) } returns listOf(productStock1, productStock2)
 
         // when
         val result = productStockService.valid(productOrders)
@@ -60,7 +60,8 @@ class ProductStockServiceTest {
             ProductOrderDto(productStockId = 1L, quantity = 5)
         )
 
-        every { productStockRepository.findByIdWithLock(1L) } returns null
+        every { productStockRepository.findExistingIds(listOf(1L)) } returns emptyList()
+        every { productStockRepository.findByIdsWithLock(listOf(1L)) } returns emptyList()
 
         // when & then
         val message = assertThrows<BusinessException.NotFound> {
@@ -80,7 +81,8 @@ class ProductStockServiceTest {
 
         val productStock = ProductStockStub.create(productId = 1L, size = "M", quantity = 1)
 
-        every { productStockRepository.findByIdWithLock(1L) } returns productStock
+        every { productStockRepository.findExistingIds(listOf(1L)) } returns listOf(1L)
+        every { productStockRepository.findByIdsWithLock(listOf(1L)) } returns listOf(productStock)
 
         // when & then
         val message = assertThrows<BusinessException.BadRequest> {


### PR DESCRIPTION
- 작업 내용
- [x] 주문 요청 시 비관적 락 적용

---
- PR 목적
기존 주문 요청 처리 할 때 상품 상세정보 Id를 list 형식으로 받아 foreach 락을 적용 하던 부분을 list로 한 번에 전달해 쿼리에서 in 하는 방법으로 수정 했습니다.
수정한 이유는 락을 거는 포인트가 foreach 안에 있어 코드 가독성이 떨어진다 판단하여 수정 하였습니다.
통합 테스트는 시간을 측정해 얼마나 시간이 걸리는지 확인 했습니다.
이에 대한 보고서는 추후 보고서를 작성 후 다시 올리겠습니다.


---
메인 branch merge 목적이 아닌, 팀원들과 코드를 공유하기 위한 PR 입니다.